### PR TITLE
Removed globbing from dox.files.src (in Gruntfile.js)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -235,7 +235,7 @@ module.exports = function(grunt) {
         },
         dox: {
           files: {
-            src: ['<%= basepath %><%= app.build.js %>**/*.js'],
+            src: ['<%= basepath %><%= app.build.js %>'],
             dest: '<%= basepath %><%= app.build.docs.dest %>'
           },
           options: config.build.docs.options || {}


### PR DESCRIPTION
Dox-task fails if we feed it a list of files (which the globbing pattern does), using app.build.js-directory without globbing instead.
