### PR TITLE
Changed 'extend', to 'xtend' :)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -176,7 +176,7 @@ module.exports = function(grunt) {
 
       if(typeof config.build.min !== 'undefined'){
 
-        patsy.gruntConfig = extend(patsy.gruntConfig,{
+        patsy.gruntConfig = xtend(patsy.gruntConfig,{
           uglify : {
             project : {
               files : {


### PR DESCRIPTION
Latest update (0.2.6-beta) breaks here:

Loading "Gruntfile.js" tasks...ERROR

> > ReferenceError: extend is not defined
> >     at Object.module.exports (/Users/nils/Sites/work/patsy/Gruntfile.js:179:29)
